### PR TITLE
Remove EdgeX CLI from default config

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,9 +6,6 @@
         "edgex-device-virtual": {
             "githubRepo": "edgexfoundry/device-virtual-go"
         },
-        "edgex-cli": {
-            "githubRepo": "edgexfoundry/edgex-cli"
-        },
         "edgex-ekuiper": {
             "githubRepo": "canonical/edgex-ekuiper-snap"
         },


### PR DESCRIPTION
[EdgeX CLI](https://github.com/edgexfoundry/edgex-cli) has been deprecated and will not have a v3 release.