### PR TITLE
Re-purpose to report Matter snap results

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,6 +2,12 @@
     "snaps": {
         "chip-tool":{
             "githubRepo": "canonical/chip-tool-snap"
+        },
+        "matter-pi-gpio-commander":{
+            "githubRepo": "canonical/matter-pi-gpio-commander"
+        },
+        "openthread-border-router":{
+            "githubRepo": "canonical/openthread-border-router-snap"
         }
     }
 }

--- a/config.json
+++ b/config.json
@@ -1,46 +1,7 @@
 {
     "snaps": {
-        "edgexfoundry": {
-            "githubRepo": "edgexfoundry/edgex-go"
-        },
-        "edgex-device-virtual": {
-            "githubRepo": "edgexfoundry/device-virtual-go"
-        },
-        "edgex-ekuiper": {
-            "githubRepo": "canonical/edgex-ekuiper-snap"
-        },
-        "edgex-ui": {
-            "githubRepo": "edgexfoundry/edgex-ui-go"
-        },
-        "edgex-device-modbus": {
-            "githubRepo": "edgexfoundry/device-modbus-go"
-        },
-        "edgex-device-snmp": {
-            "githubRepo": "edgexfoundry/device-snmp-go"
-        },
-        "edgex-device-rest": {
-            "githubRepo": "edgexfoundry/device-rest-go"
-        },
-        "edgex-device-mqtt": {
-            "githubRepo": "edgexfoundry/device-mqtt-go"
-        },
-        "edgex-device-gpio": {
-            "githubRepo": "edgexfoundry/device-gpio"
-        },
-        "edgex-device-rfid-llrp": {
-            "githubRepo": "edgexfoundry/device-rfid-llrp-go"
-        },
-        "edgex-device-usb-camera": {
-            "githubRepo": "edgexfoundry/device-usb-camera"
-        },
-        "edgex-device-onvif-camera": {
-            "githubRepo": "edgexfoundry/device-onvif-camera"
-        },
-        "edgex-app-service-configurable": {
-            "githubRepo": "edgexfoundry/app-service-configurable"
-        },
-        "edgex-app-rfid-llrp-inventory": {
-            "githubRepo": "edgexfoundry/app-rfid-llrp-inventory"
+        "chip-tool":{
+            "githubRepo": "canonical/chip-tool-snap"
         }
     }
 }

--- a/logger/log.go
+++ b/logger/log.go
@@ -29,8 +29,7 @@ func Infof(format string, args ...interface{}) {
 }
 
 func Infoln(args ...interface{}) {
-	msg := white + fmt.Sprint(args...) + reset
-	log.Println(msg)
+	Infof(fmt.Sprint(args...))
 }
 
 func Warnf(format string, args ...interface{}) {
@@ -39,8 +38,7 @@ func Warnf(format string, args ...interface{}) {
 }
 
 func Warnln(args ...interface{}) {
-	msg := yellow + fmt.Sprint(args...) + reset
-	log.Println(msg)
+	Warnf(fmt.Sprint(args...))
 }
 
 func Errorf(format string, args ...interface{}) {
@@ -49,8 +47,7 @@ func Errorf(format string, args ...interface{}) {
 }
 
 func Errorln(args ...interface{}) {
-	msg := red + fmt.Sprint(args...) + reset
-	log.Println(msg)
+	Errorf(fmt.Sprint(args...))
 }
 
 func Fatalf(format string, args ...interface{}) {
@@ -59,6 +56,5 @@ func Fatalf(format string, args ...interface{}) {
 }
 
 func Fatalln(args ...interface{}) {
-	msg := red + fmt.Sprint(args...) + reset
-	log.Fatalln(msg)
+	Fatalf(fmt.Sprint(args...))
 }

--- a/main.go
+++ b/main.go
@@ -141,29 +141,6 @@ func querySnapStore(snapName string) (*snapInfo, error) {
 	return &info, nil
 }
 
-type builds struct {
-	Entries []struct {
-		StoreUploadRevision *uint `json:"store_upload_revision"`
-		BuildState          string
-	}
-}
-
-func queryLaunchpad(projectName string) (*builds, error) {
-	logger.Infoln("Querying Launchpad for:", projectName)
-	res, err := http.Get(fmt.Sprintf("https://api.launchpad.net/devel/~canonical-edgex/+snap/%s/builds?ws.size=10&direction=backwards&memo=0", projectName))
-	if err != nil {
-		return nil, err
-	}
-
-	var builds builds
-	err = json.NewDecoder(res.Body).Decode(&builds)
-	if err != nil {
-		return nil, err
-	}
-
-	return &builds, nil
-}
-
 type runs struct {
 	WorkflowRuns []struct {
 		Name         string

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ func main() {
 	t := table.NewWriter()
 	t.SetOutputMirror(os.Stdout)
 	t.SetStyle(table.StyleColoredBright)
-	t.AppendHeader(table.Row{"Name", "Channel", "Version", "Arch", "Rev", "Date", "Build"})
+	t.AppendHeader(table.Row{"Name", "Channel", "Version", "Arch", "Rev", "Date", "Build", "Test"})
 
 	t.SetColumnConfigs([]table.ColumnConfig{
 		{Number: 1, AutoMerge: true},
@@ -52,44 +52,16 @@ func main() {
 			logger.Fatalf("Error querying snap store: %s", err)
 		}
 
-		// launchpad
-		builds, err := queryLaunchpad(k)
-		if err != nil {
-			logger.Fatalf("Error querying launchpad: %s", err)
-		}
-		revisionBuildStatus := make(map[uint]string)
-		for _, v := range builds.Entries {
-			// Setting a check mark only if we find the successful build result for a given revision.
-			// Alternative scenarios include results that have no revision number because:
-			// - build or artifact upload has failed (an actual failure)
-			// - build is too old and not returned in the query
-			// - build or artifact upload is pending
-			if v.StoreUploadRevision != nil && v.BuildState == "Successfully built" {
-				revisionBuildStatus[*v.StoreUploadRevision] = "✅"
-			}
-		}
-
 		// github
 		runs, err := queryGithub(v.GithubRepo)
 		if err != nil {
 			logger.Fatalf("Error querying launchpad: %s", err)
 		}
-		var totalSnapRuns, failedSnapRuns uint
-		testIcon := "🔴"
-		for _, run := range runs.WorkflowRuns {
-			if run.Name == "Snap Testing" {
-				totalSnapRuns++
-			}
-			if run.Conclusion == "failure" {
-				failedSnapRuns++
-				logger.Errorf("🔴 %s (%s)", run.DisplayTitle, run.HTMLURL)
-			}
-		}
-		if totalSnapRuns == 0 { // something is not right
-			testIcon = "🟠"
-		} else if failedSnapRuns == 0 {
-			testIcon = "🟢"
-		}
+		var build, test snapStatistcs
+		build.runName = "Snap Builder"
+		test.runName = "Snap Testing"
+		handleRun(runs, &build)
+		handleRun(runs, &test)
 
 		// fill the table
 		for _, cm := range info.ChannelMap {
@@ -100,17 +72,35 @@ func main() {
 				cm.Channel.Architecture,
 				cm.Revision,
 				cm.Channel.ReleasedAt.Format(time.Stamp),
-				revisionBuildStatus[cm.Revision],
+				fmt.Sprintf("%d/%d", build.success, build.total),
+				fmt.Sprintf("%d/%d", test.success, test.total),
 			}, table.RowConfig{AutoMerge: true})
 		}
-		t.AppendRow(table.Row{
-			fmt.Sprintf("%s failed %d/%d", testIcon, failedSnapRuns, totalSnapRuns),
-			"", "", "", "", "", "",
-		}, table.RowConfig{AutoMerge: true})
+
 		t.AppendSeparator()
 	}
 
 	t.Render()
+}
+
+type snapStatistcs struct {
+	total, success uint
+	runName        string
+}
+
+func handleRun(run *runs, s *snapStatistcs) {
+	for _, r := range run.WorkflowRuns {
+		if r.Name != s.runName {
+			continue
+		}
+		s.total++
+		if r.Conclusion == "success" {
+			*&s.success++
+			// logger.Successf("🟢 %s (%s)", r.DisplayTitle, r.HTMLURL)
+		} else {
+			logger.Errorf("🔴 %s (%s)", r.DisplayTitle, r.HTMLURL)
+		}
+	}
 }
 
 type snapInfo struct {


### PR DESCRIPTION
This PR modifies the functionality of `snap-info-tool` to query information on Matter snaps.